### PR TITLE
use defined expiration var `cacheExpiration` when setting transient

### DIFF
--- a/includes/PluginUpdater.php
+++ b/includes/PluginUpdater.php
@@ -154,7 +154,7 @@ class PluginUpdater {
 					$data = json_decode( $body, true );
 					if ( ! is_null( $data ) ) {
 						$payload = $this->mapData( $data );
-						set_transient( $cache_key, $payload, HOUR_IN_SECONDS * 6 );
+						set_transient( $cache_key, $payload, $this->cacheExpiration );
 					}
 				}
 			}


### PR DESCRIPTION
## Proposed changes

Currently, there is a protected class variable `cacheExpiration`. This value is not used anywhere. It should be used when saving the release payload as transient. Instead the transient is set with the repeated value of 6 hours.

This PR uses the value that is in place already as it appears to be intended for. So, now if someone sets the expiration it will actually be used.

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

<!-- - [] I have read the [CONTRIBUTING](https://github.com/wp-forge/.github/blob/master/.github/CONTRIBUTING.md) doc -->
- [] Linting and tests pass locally with my changes
- [] I have added tests that prove my fix is effective or that my feature works
- [] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
